### PR TITLE
Update JSON response keys to "data" instead of others

### DIFF
--- a/pkg/settings/get_settings.go
+++ b/pkg/settings/get_settings.go
@@ -38,5 +38,5 @@ func (h handler) GetSettings(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"settings": settings})
+	c.JSON(http.StatusOK, gin.H{"data": settings})
 }

--- a/pkg/tasks/get_task.go
+++ b/pkg/tasks/get_task.go
@@ -51,5 +51,5 @@ func (h handler) GetTask(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"task": task})
+	c.JSON(http.StatusOK, gin.H{"data": task})
 }

--- a/pkg/tasks/get_tasks.go
+++ b/pkg/tasks/get_tasks.go
@@ -191,7 +191,7 @@ func (h handler) GetTasks(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"tasks": tasks,
+		"data": tasks,
 		"pagination": gin.H{
 			"count":         len(tasks),
 			"page":          page,

--- a/pkg/tasks/get_tasks_for_today.go
+++ b/pkg/tasks/get_tasks_for_today.go
@@ -56,6 +56,6 @@ func (h handler) GetTasksForToday(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"tasks": tasks,
+		"data": tasks,
 	})
 }

--- a/pkg/users/get_user.go
+++ b/pkg/users/get_user.go
@@ -43,5 +43,5 @@ func (h handler) GetUser(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"user": user})
+	c.JSON(http.StatusOK, gin.H{"data": user})
 }


### PR DESCRIPTION
Standardize API response, change key names to "data".